### PR TITLE
Switch to org-element-map based finding of upcoming events

### DIFF
--- a/org-upcoming-modeline.el
+++ b/org-upcoming-modeline.el
@@ -129,30 +129,31 @@ Used by `org-upcoming-modeline-snooze'."
 Store it in `org-upcoming-modeline--current-event'."
   (setq
    org-upcoming-modeline--current-event
-   (when-let*
-       ((items (remove
-                nil
-                (org-ql-select (org-agenda-files)
-                  `(ts-active :from 0
-                              :to ,org-upcoming-modeline-days-ahead)
-                  :action '(when-let* ((mark (point-marker))
-                                       (bound (save-excursion (outline-next-heading) (point)))
-                                       (time (save-excursion
-                                               (car
-                                                (sort (cl-loop while (re-search-forward org-tsr-regexp bound 'noerror)
-                                                               for org-ts-string = (match-string 1)
-                                                               when org-ts-string
-                                                               for time = (org-upcoming-modeline--parse-ts org-ts-string)
-                                                               when (and time
-                                                                         (ts>= time (ts-now)))
-                                                               collect time)
-                                                      #'ts<)))))
-                             (cons time mark))))))
-     (pcase-let*
-         ((`(,time . ,marker) (car (seq-sort-by #'car #'ts< items)))
-          (heading (org-with-point-at marker
-                     (org-link-display-format (nth 4 (org-heading-components))))))
-       (list time heading marker)))))
+   (first
+    (remove-if (lambda (thing) (ts< (car thing) (ts-now)))
+               (seq-sort-by #'car #'ts<
+                            (org-element-map (org-ql-select (org-agenda-files)
+                                               `(ts-active :from 0
+                                                           :to ,org-upcoming-modeline-days-ahead)
+                                               :action 'element-with-markers
+                                               :sort 'scheduled)
+                                '(headline)
+                              (lambda (headline)
+                                (let ((mark (first (last (first (last headline)))))
+                                      (title-thing (org-element-property :title headline)))
+                                  (cond
+                                   ((org-element-property :scheduled headline)
+                                    (let ((timestamp (org-element-property :raw-value (org-element-property :scheduled headline)))
+                                          (text (org-element-property :raw-value headline)))
+                                      (list (org-upcoming-modeline--parse-ts timestamp) (substring-no-properties text) mark)))
+                                   (t
+                                    (let ((timestamp (org-element-property :raw-value
+                                                                           (first (remove-if-not (lambda (thing)
+                                                                                                   (eq (org-element-type thing) 'timestamp))
+                                                                                                 title-thing))))
+                                          (text (first (remove-if (lambda (thing) (eq (org-element-type thing) 'timestamp)) title-thing))))
+                                      (list (org-upcoming-modeline--parse-ts timestamp) (substring-no-properties text) mark))))))))))))
+
 
 ;;;###autoload
 (define-minor-mode org-upcoming-modeline-mode


### PR DESCRIPTION
This also a) de-propertizes the strings, b) cleanly handles "scheduled" items, and c) does everything in one fell swoop.

Note, if you use this, #4 is unnecessary.  This would likely be more helpful.